### PR TITLE
 changed requested by Patrick, removed dominic's name and rest changes

### DIFF
--- a/xml/MAIN-SBP-MSP-UpdateInfra.xml
+++ b/xml/MAIN-SBP-MSP-UpdateInfra.xml
@@ -45,16 +45,6 @@
   <authorgroup>
    <author>
     <personname>
-     <firstname>Dominic</firstname>
-     <surname>Geevarghese</surname>
-    </personname>
-    <affiliation>
-     <jobtitle>MSP Solution Architect</jobtitle>
-     <orgname>SUSE</orgname>
-    </affiliation>
-   </author>
-   <author>
-    <personname>
      <firstname>Mike</firstname>
      <surname>Friesenegger</surname>
     </personname>
@@ -150,7 +140,7 @@
    Repository Mirroring Tool (RMT) or to the &scc; (SCC). </para>
 
   <para> Generating registration entitlements for every instance in a cloud environment for use with
-   SCC and providing these to the user does not meet the <quote>fire up and use</quote> expectation. </para>
+   SCC and providing these to the user does not meet the <quote>start and use</quote> expectation. </para>
 
   <para> RMT establishes a local cache of the SCC content for &sls; based products. Registration
    can be fully automated against RMT to meet the expectations in a cloud environment. </para>
@@ -256,7 +246,7 @@
    <title>RMT server(s)</title>
 
    <para> The RMT server serves as cache for the package repositories obtained from SCC. The RMT
-    server itself is registered with SCC, or managed via &suma;, as it would be in a traditional
+    server itself is registered with SCC, or managed via SUSE Multi-Linux Manager;, as it would be in a traditional
     data center. </para>
    <para> Given the data provided by a Region Server, the client proceeds through a
      <quote>regular</quote> automated registration process. This registration process is identical


### PR DESCRIPTION
updated the changes below. 
"A few items. 
1. You can remove Dominic's name from the contributing authors. 
2. You still have some references to SUSE Manager in the document, please use the current branding: SUSE Multi-Linux Manager
3. In the introduction, you switch between the terms "start and use" and "fire up and use"  - pick one. "